### PR TITLE
Updated some links

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ See the [issues](https://github.com/ConsenSysLabs/ethereum-developer-tools-list/
 
 * [Ethers.js](https://github.com/ethers-io/ethers.js/)- Web3 Alternative
 
-* [Drizzle](https://github.com/truffle-box/drizzle-box) -  Redux library to connect a frontend to a blockchain
+* [Drizzle](https://github.com/trufflesuite/drizzle) -  Redux library to connect a frontend to a blockchain
 
 ### Example Smart Contract Repos and reusuable libraries
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ See the [issues](https://github.com/ConsenSysLabs/ethereum-developer-tools-list/
 
 * Javascript- Client side language for interacting with smart contracts
 
-    * Web3.js- Javascript API for interacting with the Ethereum Blockchain
+    * [Web3.js](https://github.com/ethereum/web3.js/) - Javascript API for interacting with the Ethereum Blockchain
 
-    * Ethers.js- Javascript Ethereum wallet implementation and utilities
+    * [Ethers.js](https://github.com/ethers-io/ethers.js) - Javascript Ethereum wallet implementation and utilities
 
 * Typescript- javascript with type safety, backwards compatible
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ See the [issues](https://github.com/ConsenSysLabs/ethereum-developer-tools-list/
 
 ### Programming Languages
 
-* [Solidity](http://solidity.readthedocs.io/en/v0.4.24/)- Ethereum smart contracting language. Read the docs, play [CryptoZombies](https://cryptozombies.io/) and [Chainshot building blocks](https://www.chainshot.com/), or checkout [Consensys Academy](https://consensys.net/academy/resources/)
+* [Solidity](http://solidity.readthedocs.io/en/v0.4.24/) - Ethereum smart contracting language. Read the docs, play [CryptoZombies](https://cryptozombies.io/) and [Chainshot building blocks](https://www.chainshot.com/), or checkout [Consensys Academy](https://consensys.net/academy/resources/)
 
-* Javascript- Client side language for interacting with smart contracts
+* Javascript - Client side language for interacting with smart contracts
 
     * [Web3.js](https://github.com/ethereum/web3.js/) - Javascript API for interacting with the Ethereum Blockchain
 
@@ -56,7 +56,7 @@ See the [issues](https://github.com/ConsenSysLabs/ethereum-developer-tools-list/
 
 * Python
 
-    * [Web3.py ](https://github.com/ethereum/web3.py)- python implementation of web3.js
+    * [Web3.py ](https://github.com/ethereum/web3.py) - python implementation of web3.js
 
 ### Bootstrap/out of box tools
 


### PR DESCRIPTION

I added some links to web3.js and ethers.js. I saw they were in the front end library section too. Just thought it would be nice to link them in both sections. I also changed the drizzle link to the library repo instead of the truffle-box repo.

Let me know if you don't agree with those links. I also found web3.js readthedocs, but it seemed out of date. I found Ethers.js [docs site](https://docs.ethers.io/ethers.js/html/) if that is preferred.

#### Summary of Updates
- Updated Web3.js in programming languages section
- Updated Ethers.js in programming languages section
- Changed Drizzle link to point to the drizzle repo instead of the truffle-box
- Fixed some hyphens