### PR TITLE
Include OrbitDB (decentralised DB on top of IPFS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ See the [issues](https://github.com/ConsenSysLabs/ethereum-developer-tools-list/
 
 * [IPFS](https://ipfs.io/) - Decentralized storage and file referencing 
 
+* [OrbitDB](https://github.com/orbitdb/orbit-db) - Decentralized database on top of IPFS
+
 ### Developer IDE's and tools
 
 * [Remix-](https://remix.ethereum.org/) Web IDE with built in static analysis, test blockchain VM.


### PR DESCRIPTION
Include the OrbitDB database [https://github.com/orbitdb/orbit-db](https://github.com/orbitdb/orbit-db)