### PR TITLE
Add py-eth to developer ides and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Feel free to submit a pull request, with anything from small fixes to tools you'
 
 * [ethereum-graph-debugger](https://github.com/fergarrui/ethereum-graph-debugger) - Solidity graph debugger
 
+* [py-eth](http://www.py-eth.com) - Collection of Python tools for the Ethereum ecosystem
+
 ### Programming Languages (for writing smart contracts, compiles to Ethereum Virtual Machine Bytecode)
 
 * [Solidity](http://solidity.readthedocs.io/en/v0.4.24/) - Ethereum smart contracting language. Read the docs, play [CryptoZombies](https://cryptozombies.io/) and [Chainshot building blocks](https://www.chainshot.com/), or checkout [Consensys Academy](https://consensys.net/academy/resources/)


### PR DESCRIPTION
Add link to `www.py-eth.com`: a collection of tooling built in Python for the Ethereum ecosystem.