### PR TITLE
Removing "Solutions PoC starter app"

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Feel free to submit a pull request, with anything from small fixes to tools you'
 
 #### Bootstrap/out of box tools
 * [Truffle boxes](http://truffleframework.com/boxes/) - Packaged components for the Ethereum ecosystem
-* [Solutions PoC starter app](https://github.com/ConsenSys/solutions-poc-starter) - Simple MERN stack with built in token use case, uPort signing, and more
 * [Local Raiden](https://github.com/ConsenSys/Local-Raiden) - Run a local Raiden network in docker containers for demo and testing purposes
 * [Private networks deployment scripts](https://github.com/ConsenSys/private-networks-deployment-scripts) - Out-of-the-box deployment scripts for private PoA networks
 * [Local Ethereum Network](https://github.com/ConsenSys/local_ethereum_network) - Out-of-the-box deployment scripts for private PoW networks


### PR DESCRIPTION
Removing "Solutions PoC starter app" from "Bootstrap" section: The link to the project is broken: this project was probably deleted (or moved, but impossible to find the new repo)