### PR TITLE
New security scanner: https://securify.ch

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ Feel free to submit a pull request, with anything from small fixes to tools you'
 
 #### Security
 * [Mythril](https://github.com/ConsenSys/mythril) - Static smart contract security analysis
-* [Securify](https://securify.ch) - Security scanner for Ethereum smart contracts
 * [Oyente](https://github.com/melonproject/oyente) - Alternative static smart contract security analysis
+* [Securify](https://securify.ch) - Security scanner for Ethereum smart contracts
 * [Porosity](https://github.com/comaeio/porosity) - Decompiler and Security Analysis tool for Blockchain-based Ethereum Smart-Contracts
 * [Ethersplay](https://github.com/trailofbits/ethersplay) - EVM disassembler
 * [Evmdis](https://github.com/Arachnid/evmdis) - Alternative EVM disassembler

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Feel free to submit a pull request, with anything from small fixes to tools you'
 
 #### Security
 * [Mythril](https://github.com/ConsenSys/mythril) - Static smart contract security analysis
+* [Securify](https://securify.ch) - Security scanner for Ethereum smart contracts
 * [Oyente](https://github.com/melonproject/oyente) - Alternative static smart contract security analysis
 * [Porosity](https://github.com/comaeio/porosity) - Decompiler and Security Analysis tool for Blockchain-based Ethereum Smart-Contracts
 * [Ethersplay](https://github.com/trailofbits/ethersplay) - EVM disassembler


### PR DESCRIPTION
Yesterday we released the full version of a new security scanner: https://securify.ch

Should be added to the list.