### PR TITLE
Adding truffle-flattener

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Feel free to submit a pull request, with anything from small fixes to tools you'
 * [Ethereum ABI UI](https://github.com/hiddentao/ethereum-abi-ui) - Auto-generate UI form field definitions and associated validators from an Ethereum contract ABI
 * [Eth crypto](https://github.com/pubkey/eth-crypto) - Cryptographic javascript-functions for Ethereum and tutorials to use them with web3js and solidity
 * [Solidity flattener](https://github.com/poanetwork/solidity-flattener) - Combine solidity project to flat file utility
+* [truffle-flattener](https://github.com/alcuadrado/truffle-flattener) - Concats solidity files developed under Truffle with all of their dependencies
 * [JS IPFS API](https://github.com/ipfs/js-ipfs-api) - A client library for the IPFS HTTP API, implemented in JavaScript.
 * [Ganache](https://github.com/trufflesuite/ganache) - App for test Ethereum blockchain with visual UI and logs
 * [SpankCard](https://github.com/SpankChain/SpankCard) - An in-browser Ethereum wallet with support for payment channels


### PR DESCRIPTION
truffle-flattener

* https://github.com/alcuadrado/truffle-flattener
* https://www.npmjs.com/package/truffle-flattener

Truffle Flattener concats solidity files developed under Truffle with all of their dependencies.

I have used for several months with great success.